### PR TITLE
Fix broken links to the Generic Installation and Configuration guide

### DIFF
--- a/indigo1/cpr1.md
+++ b/indigo1/cpr1.md
@@ -47,7 +47,7 @@ Supported platforms
 * Both provide */etc/init.d/cloudproviderranker start/stop* script. 
 * Installation of RPM also starts the service; de-installation stops the service
 
-After setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](generic_installation_and_configuration_guide_1.md):
+After setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](../generic_installation_and_configuration_guide_1.md):
 * On CentOS 7, as root or otherwise using sudo:<br>
   ```$ yum install -y https://repos.fedorapeople.org/openstack/openstack-liberty/rdo-release-liberty-5.noarch.rpm```<br>
   ```$ yum clean all```<br>

--- a/indigo1/indigo1/keystone_library1.md
+++ b/indigo1/indigo1/keystone_library1.md
@@ -41,7 +41,7 @@ access_token (so three different auth plugins)
 
 <a id="id4"></a>
 ### Deployment Notes
-After setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](generic_installation_and_configuration_guide_1.md):
+After setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](../generic_installation_and_configuration_guide_1.md):
 * On CentOS 7, as root or otherwise using sudo:<br>
   ```$ yum install -y https://repos.fedorapeople.org/openstack/openstack-liberty/rdo-release-liberty-5.noarch.rpm```<br>
   ```$ yum clean all```<br>

--- a/indigo1/nova-docker1.md
+++ b/indigo1/nova-docker1.md
@@ -32,7 +32,7 @@ Supported Platforms:
 <a id="id4"></a>
 ### Deployment Notes
 
-After setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](generic_installation_and_configuration_guide_1.md):
+After setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](../generic_installation_and_configuration_guide_1.md):
 * On CentOS 7, as root or otherwise using sudo:<br>
   ```$ yum install -y https://repos.fedorapeople.org/openstack/openstack-liberty/rdo-release-liberty-5.noarch.rpm```<br>
   ```$ yum clean all```<br>

--- a/indigo1/ooi1.md
+++ b/indigo1/ooi1.md
@@ -47,7 +47,7 @@ Ssupported Platforms:
 <a id="id4"></a>
 ### Deployment Notes
 
-After setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](generic_installation_and_configuration_guide_1.md):
+After setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](../generic_installation_and_configuration_guide_1.md):
 * On CentOS 7, as root or otherwise using sudo:<br>
   ```$ yum install -y https://repos.fedorapeople.org/openstack/openstack-liberty/rdo-release-liberty-5.noarch.rpm```<br>
   ```$ yum clean all```<br>

--- a/indigo1/ophidia1.md
+++ b/indigo1/ophidia1.md
@@ -53,7 +53,7 @@ Please see the commits for each of the components:
 <a id="id4"></a>
 ### Deployment Notes
 
-After setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](generic_installation_and_configuration_guide_1.md) please follow the instructions present in the [Ophidia Admin Guide]( http://ophidia.cmcc.it/documentation/admin/index.html)
+After setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](../generic_installation_and_configuration_guide_1.md) please follow the instructions present in the [Ophidia Admin Guide]( http://ophidia.cmcc.it/documentation/admin/index.html)
 
 
 * installation and configuration can be done also using[ ansible-role-ophidia-all](https://github.com/indigo-dc/ansible-role-ophidia-all)

--- a/indigo1/opie1.md
+++ b/indigo1/opie1.md
@@ -41,7 +41,7 @@ Supported Platforms:
 <a id="id4"></a>
 ### Deployment Notes
 
-After setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](generic_installation_and_configuration_guide_1.md):
+After setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](../generic_installation_and_configuration_guide_1.md):
 * On CentOS 7, as root or otherwise using sudo:<br>
   ```$ yum install -y https://repos.fedorapeople.org/openstack/openstack-liberty/rdo-release-liberty-5.noarch.rpm```<br>
   ```$ yum clean all```<br>

--- a/indigo1/pocci1.md
+++ b/indigo1/pocci1.md
@@ -58,7 +58,7 @@ List of bugfixes and extensions:
 <a id="id4"></a>
 ### Deployment Notes
 
-After setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](generic_installation_and_configuration_guide_1.md):
+After setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](../generic_installation_and_configuration_guide_1.md):
 * On CentOS 7 
 
 ```$ yum clean all```<br>
@@ -66,7 +66,7 @@ After setting the INDIGO-DC repositories as explained in the [Generic Installati
 or
 ```$ yum install python3-pOCCI```
 
-* On Ubuntu 14.04 - after setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](generic_installation_and_configuration_guide_1.md):
+* On Ubuntu 14.04 - after setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](../generic_installation_and_configuration_guide_1.md):
 
 ```$ apt-get update```<br>
 ```$ apt-get install python-pocci```<br>

--- a/indigo1/python-osclient1.md
+++ b/indigo1/python-osclient1.md
@@ -37,7 +37,7 @@ Supported Platforms:
 <a id="id4"></a>
 ### Deployment Notes
 
-After setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](generic_installation_and_configuration_guide_1.md):
+After setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](../generic_installation_and_configuration_guide_1.md):
 * On CentOS 7, as root or otherwise using sudo:<br>
   ```$ yum install -y https://repos.fedorapeople.org/openstack/openstack-liberty/rdo-release-liberty-5.noarch.rpm```<br>
   ```$ yum clean all```<br>

--- a/indigo1/reposync1.md
+++ b/indigo1/reposync1.md
@@ -45,12 +45,12 @@ Supported Platforms:
 <a id="id4"></a>
 ### Deployment Notes
 
-After setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](generic_installation_and_configuration_guide_1.md):
+After setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](../generic_installation_and_configuration_guide_1.md):
 * On CentOS 7 <br>
 ```$ yum clean all```<br>
 ```$ yum install indigo-dc-reposync```
 
-* On Ubuntu 14.04 - after setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](generic_installation_and_configuration_guide_1.md) add also the JRE 1.8 PPA following the documentation present [here](https://launchpad.net/~openjdk-r/+archive/ubuntu/ppa):<br>
+* On Ubuntu 14.04 - after setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](../generic_installation_and_configuration_guide_1.md) add also the JRE 1.8 PPA following the documentation present [here](https://launchpad.net/~openjdk-r/+archive/ubuntu/ppa):<br>
   ```$ apt-get update```<br>
   ```$ apt-get install reposync```
 

--- a/indigo1/rocci1.md
+++ b/indigo1/rocci1.md
@@ -38,7 +38,7 @@ Supported Platforms:
 <a id="id4"></a>
 ### Deployment Notes
 
-After setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](generic_installation_and_configuration_guide_1.md):
+After setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](../generic_installation_and_configuration_guide_1.md):
 * On CentOS 7 
 
 ```$ yum clean all```<br>
@@ -46,7 +46,7 @@ After setting the INDIGO-DC repositories as explained in the [Generic Installati
 or
 ```$ yum install occi-cli```<br>
 
-* On Ubuntu 14.04 - after setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](generic_installation_and_configuration_guide_1.md):
+* On Ubuntu 14.04 - after setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](../generic_installation_and_configuration_guide_1.md):
 
 ```$ apt-get update```<br>
 ```$ apt-get install occi-server```<br>

--- a/indigo1/tosca-pt1.md
+++ b/indigo1/tosca-pt1.md
@@ -48,12 +48,12 @@ Supported Platforms:
 <a id="id4"></a>
 ### Deployment Notes
 
-After setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](generic_installation_and_configuration_guide_1.md):
+After setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](../generic_installation_and_configuration_guide_1.md):
 * On CentOS 7 <br>
   ```$ yum clean all``` <br>
   ```$ yum install tosca-parser```
 
-* On Ubuntu 14.04 - after setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](generic_installation_and_configuration_guide_1.md):<br>
+* On Ubuntu 14.04 - after setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](../generic_installation_and_configuration_guide_1.md):<br>
   ```$ apt-get update```<br>
   ```$ apt-get install python-tosca-parser```
 

--- a/indigo1/tts1.md
+++ b/indigo1/tts1.md
@@ -41,14 +41,14 @@ Supported Platforms:
 <a id="id4"></a>
 ### Deployment Notes
 
-After setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](generic_installation_and_configuration_guide_1.md):
+After setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](../generic_installation_and_configuration_guide_1.md):
 * On CentOS 7 
 
   ```$ yum clean all```
 
   ```$ yum install tts```
 
-* On Ubuntu 14.04 - after setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](generic_installation_and_configuration_guide_1.md):
+* On Ubuntu 14.04 - after setting the INDIGO-DC repositories as explained in the [Generic Installation & Configuration Guide](../generic_installation_and_configuration_guide_1.md):
 
   ```$ apt-get update```
   


### PR DESCRIPTION
It sould fix links to the Generic Installation and Configuration guide that is in fact available in the parent directory.