### PR TITLE
generic install: fix URL to indigodc-release_1.0.0-2_amd64.deb

### DIFF
--- a/generic_installation_and_configuration_guide_1.md
+++ b/generic_installation_and_configuration_guide_1.md
@@ -114,7 +114,7 @@ Install INDIGO - DataCloud repositories :
 ```yum localinstall -y indigodc-release-1.0.0-1.el7.centos.noarch.rpm``` 
 
 * Ubuntu 14.04:<br>
-```wget http://repo.indigo-datacloud.eu/repository/indigo/1/ubuntu/dists/trusty/main/binary-amd64/indigodc-release_1.0.0-2_amd64.deb```<br>
+```wget http://repo.indigo-datacloud.eu/repository/indigo/1/ubuntu/dists/trusty-updates/main/binary-amd64/indigodc-release_1.0.0-2_amd64.deb```<br>
 ```dpkg -i indigodc-release_1.0.0-1_amd64.deb``` 
 
 These packages will install required dependencies, the INDIGO - DataCloud public key and ensures the precedence of INDIGO - DataCloud repositories over EPEL and Ubuntu. 


### PR DESCRIPTION
Fix path to indigodc-release_1.0.0-2_amd64.deb, it is available in the trusty-updates folder.